### PR TITLE
chore: rename org from Wuji-Technology-Co-Ltd to wuji-technology

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wuji_hand_description"]
 	path = wuji_hand_description
-	url = https://github.com/Wuji-Technology-Co-Ltd/wuji_hand_description
+	url = https://github.com/wuji-technology/wuji_hand_description

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://github.com/user-attachments/assets/4b3d6d5c-420e-4e15-bbe7-68bcad9729f0
 
 1. Clone the repository with submodules:
 ```bash
-git clone --recursive https://github.com/Wuji-Technology-Co-Ltd/mujoco-sim.git
+git clone --recursive https://github.com/wuji-technology/mujoco-sim.git
 cd mujoco-sim
 ```
 
@@ -29,7 +29,7 @@ The script loads the default right hand model and plays the trajectory from `dat
 
 ## Update Models
 
-To update the hand models (MJCF, meshes, etc.) to the latest version from the [description repository](https://github.com/Wuji-Technology-Co-Ltd/wuji_hand_description):
+To update the hand models (MJCF, meshes, etc.) to the latest version from the [description repository](https://github.com/wuji-technology/wuji_hand_description):
 
 ```bash
 git submodule update --remote


### PR DESCRIPTION
将所有 GitHub 组织名引用从 `Wuji-Technology-Co-Ltd` 更新为 `wuji-technology`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新了主仓库地址和相关描述文档链接，以适配组织结构变更。

* **维护**
  * 更新子模块配置中的仓库地址，确保所有引用指向正确的新位置。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->