### PR TITLE
docs: add release badge to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-11-27
+
+### Added
+
+- Main simulation script `run_sim.py` for loading and controlling Wuji Hand in MuJoCo
+- Trajectory playback from `data/wave.npy` with loop support
+- Support for both left and right hand configurations
+- Wuji Hand model as git submodule (`wuji_hand_description/`)
+- Video demo in `assets/` directory
+- Requirements file for Python dependencies
+
+[Unreleased]: https://github.com/wuji-technology/mujoco-sim/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/wuji-technology/mujoco-sim/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mujoco-sim
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/wuji-technology/mujoco-sim)](https://github.com/wuji-technology/mujoco-sim/releases)
 
 Simulation demo (MuJoCo): minimal demo for loading and controlling the Wuji Hand in MuJoCo simulator.
 


### PR DESCRIPTION
## Summary
- Add release badge to README for easy access to latest releases

## Test plan
- [ ] Verify badge renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * README 中新增 Release 徽章显示。
  * 新增 CHANGELOG，包含 Unreleased 与已发布 0.1.0 条目，记录项目变更和发布历史。

* **新功能（记录）**
  * 0.1.0 中记录首批功能：仿真/运行支持、轨迹回放（含循环）、左右手配置支持、模型子模块、演示视频与依赖清单。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->