### PR TITLE
docs: align README with Docs Center template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,45 @@
 # mujoco-sim
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)  [![Release](https://img.shields.io/github/v/release/wuji-technology/mujoco-sim)](https://github.com/wuji-technology/mujoco-sim/releases)
 
-Simulation demo (MuJoCo): minimal demo for loading and controlling the Wuji Hand in MuJoCo simulator.
+Simulation demo for MuJoCo. This repository provides a minimal example for loading and controlling the Wuji Hand in MuJoCo simulator. Loads MJCF models from the description submodule and plays pre-recorded trajectories in a loop.
 
-> For detailed usage guide, see [Wuji Hand Description Guide — MuJoCo Simulation](https://docs.wuji.technology/docs/en/wuji-hand/latest/wuji-hand-description-guide/#331-mujoco-simulation).
+**Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [Wuji Hand Description Guide — MuJoCo Simulation](https://docs.wuji.tech/docs/en/wuji-hand/latest/wuji-hand-description-guide/#331-mujoco-simulation) on Wuji Docs Center.**
 
 https://github.com/user-attachments/assets/4b3d6d5c-420e-4e15-bbe7-68bcad9729f0
 
 <video src="./assets/video.mp4" controls=""></video>
 
-## Table of Contents
-
-- [Repository Structure](#repository-structure)
-- [Usage](#usage)
-  - [Prerequisites](#prerequisites)
-  - [Installation](#installation)
-  - [Running](#running)
-- [Appendix](#appendix)
-- [Contact](#contact)
-
 ## Repository Structure
 
 ```text
-├── assets/
+├── assets/                    // Demo video files
 │   └── video.mp4
-├── data/
+├── data/                      // Pre-recorded trajectory data
 │   └── wave.npy
-├── wuji_hand_description/
-├── run_sim.py
-├── requirements.txt
+├── wuji_hand_description/     // Submodule: hand model (MJCF, meshes)
+├── run_sim.py                 // Main simulation script
+├── requirements.txt           // Python dependencies
 └── README.md
 ```
 
-### Directory Description
-
-| Directory | Description |
-|-----------|-------------|
-| `assets/` | Video demo files |
-| `data/` | Trajectory data files |
-| `wuji_hand_description/` | Hand model submodule (MJCF, meshes) |
-| `run_sim.py` | Main simulation script |
-| `requirements.txt` | Python dependencies |
-
-## Usage
-
-### Prerequisites
-
-- Python 3.8+
+## Quick Start
 
 ### Installation
-
-Clone the repository with submodules:
 
 ```bash
 git clone --recursive https://github.com/wuji-technology/mujoco-sim.git
 cd mujoco-sim
-```
-
-Install dependencies:
-
-```bash
 pip install -r requirements.txt
 ```
 
 ### Running
-
-Run the simulation with trajectory playback:
 
 ```bash
 python run_sim.py
 ```
 
 The script loads the default right hand model and plays the trajectory from `data/wave.npy` in a loop. To use the left hand, edit `side = "left"` in `run_sim.py`.
-
-## Appendix
-
-### Update Models
-
-To update the hand models (MJCF, meshes, etc.) to the latest version from the [description repository](https://github.com/wuji-technology/wuji-hand-description):
-
-```bash
-git submodule update --remote
-```
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Simulation demo (MuJoCo): minimal demo for loading and controlling the Wuji Hand in MuJoCo simulator.
 
+> For detailed usage guide, see [Wuji Hand Description Guide — MuJoCo Simulation](https://docs.wuji.technology/docs/en/wuji-hand/latest/wuji-hand-description-guide/#331-mujoco-simulation).
+
 https://github.com/user-attachments/assets/4b3d6d5c-420e-4e15-bbe7-68bcad9729f0
 
 <video src="./assets/video.mp4" controls=""></video>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ https://github.com/user-attachments/assets/4b3d6d5c-420e-4e15-bbe7-68bcad9729f0
 
 ## Quick Start
 
+### Prerequisites
+
+- Python 3.8+
+
 ### Installation
 
 ```bash
@@ -40,6 +44,14 @@ python run_sim.py
 ```
 
 The script loads the default right hand model and plays the trajectory from `data/wave.npy` in a loop. To use the left hand, edit `side = "left"` in `run_sim.py`.
+
+### Update Models
+
+To update hand models to the latest version:
+
+```bash
+git submodule update --remote
+```
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install -r requirements.txt
 python run_sim.py
 ```
 
-The script loads the default right hand model and plays the trajectory from `data/wave.npy` in a loop. To use the left hand, edit `side = "left"` in `run_sim.py`.
+The script loads the default right-hand model and plays the trajectory from `data/wave.npy` in a loop. To use the left hand, edit `side = "left"` in `run_sim.py`.
 
 ### Update Models
 


### PR DESCRIPTION
## Summary
- Rewrite README to follow Docs Center template
- Add Docs Center link paragraph and Release badge
- Replace Table of Contents and Usage with Quick Start
- Use inline comments in tree structure

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 文档
* 更新了 README 的项目徽章，新增指向发布页面的版本徽章。
* 精简并重组文档结构，移除旧目录/附录，新增“快速开始”章节以简化安装与运行指引。
* 丰富了仓库描述与模型说明，标注子模块并简化“更新模型”表述，改善目录结构展示以提升可读性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->