### PR TITLE
fix: correct anchor link to Docs Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Simulation demo for MuJoCo. This repository provides a minimal example for loading and controlling the Wuji Hand in MuJoCo simulator. Loads MJCF models from the description submodule and plays pre-recorded trajectories in a loop.
 
-**Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [Wuji Hand Description Guide — MuJoCo Simulation](https://docs.wuji.tech/docs/en/wuji-hand/latest/wuji-hand-description-guide/#331-mujoco-simulation) on Wuji Docs Center.**
+**Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [Wuji Hand Description Guide — MuJoCo Simulation](https://docs.wuji.tech/docs/en/wuji-hand/latest/wuji-hand-description-guide/#331-mujoco-simulation-example) on Wuji Docs Center.**
 
 https://github.com/user-attachments/assets/4b3d6d5c-420e-4e15-bbe7-68bcad9729f0
 


### PR DESCRIPTION
## Summary
- Fix incorrect anchor in Docs Center cross-reference link (`#331-mujoco-simulation` → `#331-mujoco-simulation-example`)

## Test plan
- [ ] Verify the link navigates to the correct section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档

* 更新 README 中的文档链接，修正了 Wuji 手部描述指南在 MuJoCo 仿真文档中的参考地址。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->