### PR TITLE
docs: 修复 README 指向文档中心的失效链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Simulation demo for MuJoCo. This repository provides a minimal example for loading and controlling the Wuji Hand in MuJoCo simulator. Loads MJCF models from the description submodule and plays pre-recorded trajectories in a loop.
 
-**Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [Wuji Hand Description Guide — MuJoCo Simulation](https://docs.wuji.tech/docs/en/wuji-hand/latest/wuji-hand-description-guide/#331-mujoco-simulation-example) on Wuji Docs Center.**
+**Get started with [Quick Start](#quick-start). For detailed documentation, please refer to [MuJoCo Simulation Example](https://docs.wuji.tech/docs/en/wuji-description/latest/related-repos/#41-mujoco-simulation-example) on Wuji Docs Center.**
 
 https://github.com/user-attachments/assets/4b3d6d5c-420e-4e15-bbe7-68bcad9729f0
 


### PR DESCRIPTION
## Summary

- README 原链接指向文档中心已下线的 Wuji Hand Description Guide 页面（返回 404）
- 改链到现行有效的 wuji-description 产品 Related Repositories 页 MuJoCo Simulation Example 章节，链接文字同步更新

## 自测结果

- 自测环境：WSL2 (Linux 6.6)，curl 带浏览器 UA 验证
- 新链接 https://docs.wuji.tech/docs/en/wuji-description/latest/related-repos/#41-mujoco-simulation-example 返回 200，锚点 id 已在渲染页面中核实存在
- README 中其余全部外链与 #quick-start 内部锚点逐一复检，均有效

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新了 “Get started with Quick Start” 的跳转链接，指向新的 MuJoCo Simulation 示例页面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->